### PR TITLE
Feature/fix for empty device groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # STAGE 1: build
-FROM docker.viriciti.com/viriciti/datahub/amd64-alpine-node:build as builder
+FROM docker.viriciti.com/viriciti/infra/builder-image:node-14-buster as builder
 
 # Create app directory
 RUN mkdir -p /app

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -18,7 +18,7 @@ cd $DIRECTORY
 VERSION="$(jq '.version' ${PKG} | cut -d'"' -f2)"
 read -p "Build App Layer Control v${VERSION}? [Y/n] " CONTINUE
 CONTINUE=${CONTINUE:Y}
-if [[ $CONTINUE =~ ^[y|Y]$ ]]; then
+if [[ ! $CONTINUE =~ ^[y|Y]$ ]]; then
     echo -e "\e[33m×\e[0m Not building"
     exit 0
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "app-layer-control",
-	"version": "5.11.2",
+	"version": "5.12.0-rc.2",
 	"private": true,
 	"scripts": {
 		"test": "mocha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "app-layer-control",
-	"version": "5.12.0-rc.2",
+	"version": "5.12.0-rc.4",
 	"private": true,
 	"scripts": {
 		"test": "mocha",

--- a/src/server/db/Watcher.coffee
+++ b/src/server/db/Watcher.coffee
@@ -48,11 +48,15 @@ class Watcher extends EventEmitter
 					data:     updatedFields
 
 				# We only want to publish the updated groups on MQTT
-				return Observable.of value unless updatedFields.groups
+				unless updatedFields.groups
+					debug "No groups in updated fields for device %s", deviceId
+					return Observable.of value
 
 				topic   = "devices/#{deviceId}/groups"
 				groups  = JSON.stringify updatedFields.groups
 				options = retain: true
+
+				debug "Publishing updated groups %s for device %s", groups, deviceId
 
 				Observable
 					.from @mqtt.publish topic, groups, options

--- a/src/server/main.coffee
+++ b/src/server/main.coffee
@@ -143,6 +143,22 @@ do ->
 			.subscribe (updates) ->
 				log.info "Updated status for #{updates.length} device(s)" if updates.length
 
+		# check for empty devicegroup
+		devicesStatus$
+			.mergeMap ({ deviceId, status }) ->
+				deviceState = await db.DeviceState.findOne { deviceId }
+
+				return if deviceState.groups?.length
+
+				deviceState.groups = [ "default" ]
+				await deviceState.save()
+
+				deviceId
+
+			.subscribe (deviceId) ->
+				if deviceId
+					log.info "Did not find groups for #{deviceId}, added default group"
+
 		# docker registry
 		registry$
 			.mergeMap (images) ->

--- a/src/server/main.coffee
+++ b/src/server/main.coffee
@@ -5,6 +5,7 @@ compression                      = require "compression"
 config                           = require "config"
 cors                             = require "cors"
 dotize                           = require "dotize"
+debug                            = (require "debug") "app:main"
 express                          = require "express"
 http                             = require "http"
 kleur                            = require "kleur"
@@ -151,7 +152,10 @@ do ->
 				return if deviceState.groups?.length
 
 				deviceState.groups = [ "default" ]
+
+				debug "[check for empty devicegroup] Saving default group for device %s", deviceId
 				await deviceState.save()
+				debug "[check for empty devicegroup] Saved default group for device %s", deviceId
 
 				deviceId
 


### PR DESCRIPTION
Unknown devices connecting for the first time stall as no specific groups configuration is posted on MQTT. This pull request fixes this. However, we still have to look for a way to use `.bufferTime 5000` in the `mergeMap` of the `deviceState$` observable in `main.coffee` on line `169`. As the `await` make the async function returns a Promise, the result of `bufferTime` would just be a list of unresolved Promises. @krapy   